### PR TITLE
Fix for #99 and some improvements when generating skin media and text.

### DIFF
--- a/classes/GameMediaGeneration.cs
+++ b/classes/GameMediaGeneration.cs
@@ -279,12 +279,11 @@ namespace GarlicPress
                         }
 
                         string fontPath = PathConstants.assetSkinPath + "font.ttf";
-                        PrivateFontCollection pfc = new PrivateFontCollection();
-                        if (File.Exists(fontPath))
-                        {
-                            pfc.AddFontFile(fontPath);
-                            using Font font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel);
+                        Font? font = null;
+                        font = GetFont(fontSize, fontPath, font);
 
+                        using (font)
+                        {
                             SizeF stringSize = graphics.MeasureString(textToDraw, font);
 
                             float adjustedY = skinMedia.Y - (stringSize.Height / 2);
@@ -317,29 +316,7 @@ namespace GarlicPress
 
                 string fontPath = Path.Combine(PathConstants.assetSkinPath, "font.ttf");
                 Font? font = null;
-
-                if (File.Exists(fontPath))
-                {
-                    try
-                    {
-                        using PrivateFontCollection pfc = new PrivateFontCollection();
-                        pfc.AddFontFile(fontPath);
-
-                        if (pfc.Families.Length > 0)
-                        {
-                            font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel);
-                        }
-                    }
-                    catch
-                    {
-
-                    }
-                }
-
-                if (font is null)
-                {
-                    font = new Font("Arial", fontSize, GraphicsUnit.Pixel);
-                }
+                font = GetFont(fontSize, fontPath, font);
 
                 using (font)
                 {
@@ -394,6 +371,34 @@ namespace GarlicPress
                     }
                 }
             }
+        }
+
+        private static Font GetFont(int fontSize, string fontPath, Font? font)
+        {
+            if (File.Exists(fontPath))
+            {
+                try
+                {
+                    using PrivateFontCollection pfc = new PrivateFontCollection();
+                    pfc.AddFontFile(fontPath);
+
+                    if (pfc.Families.Length > 0)
+                    {
+                        font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel);
+                    }
+                }
+                catch
+                {
+
+                }
+            }
+
+            if (font is null)
+            {
+                font = new Font("Arial", fontSize, GraphicsUnit.Pixel);
+            }
+
+            return font;
         }
 
         public static List<string> GetSurroundingStrings(List<string> source, int index)

--- a/classes/GameMediaGeneration.cs
+++ b/classes/GameMediaGeneration.cs
@@ -193,11 +193,32 @@ namespace GarlicPress
             graphics.DrawImage(baseImage, 0, 0, 640, 480);
             graphics.DrawImage(overlayImage, 0, 0, 640, 480);
 
-            int indexOfGame = 0;
-            try { indexOfGame = games.IndexOf(selectedGame); } catch { }
 
-            DrawGameTexts(graphics, GetSurroundingStrings(games, indexOfGame), selectedGame);
-            DrawSkinMedia(selectedSystem, graphics);
+            try
+            {
+                int indexOfGame = games.IndexOf(selectedGame);
+                if (indexOfGame == -1)
+                {
+                    indexOfGame = 0;
+                }
+
+                var surroundingGames = GetSurroundingStrings(games, indexOfGame);
+
+                DrawGameTexts(graphics, surroundingGames, selectedGame);
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Write("Error Drawing Game Text " + ex.Message, Color.OrangeRed);
+            }
+
+            try
+            {
+                DrawSkinMedia(selectedSystem, graphics);
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Write("Error Drawing System Media " + ex.Message, Color.OrangeRed);
+            }
 
             return finalImage;
         }
@@ -211,7 +232,7 @@ namespace GarlicPress
             if (GarlicSkin.skinSettings is not null)
             {
                 textColor = GarlicSkin.skinSettings.colorguide ?? "#FFFFFF";
-                fontSize = GarlicSkin.languageFiles?.FirstOrDefault()?.garlicLanguageSettings?.fontsize ?? 28;
+                fontSize = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings?.buttonguidefontsize ?? 28;
             }
 
             foreach (var skinMedia in skinMedias)
@@ -228,7 +249,10 @@ namespace GarlicPress
                                 using var stream = new FileStream(mediaPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                                 using var image = Image.FromStream(stream);
                                 using var skinImage = new Bitmap(image);
-                                graphics.DrawImage(skinImage, skinMedia.X, skinMedia.Y, skinImage.Width, skinImage.Height);
+
+                                var imagePosX = skinMedia.X - (skinImage.Width / 2);
+                                var imagePosY = skinMedia.Y - (skinImage.Height / 2);
+                                graphics.DrawImage(skinImage, imagePosX, imagePosY, skinImage.Width, skinImage.Height);
                             }
                             catch (Exception ex)
                             {
@@ -246,25 +270,27 @@ namespace GarlicPress
                         string textToDraw = skinMedia.Text;
                         switch (skinMedia.SkinMediaType)
                         {
-                            case SkinMedia.SkinMediaTypes.NavigateLabel: textToDraw = GarlicSkin.skinSettings?.navigatelabel ?? textToDraw; break;
-                            case SkinMedia.SkinMediaTypes.OpenLabel: textToDraw = GarlicSkin.skinSettings?.openlabel ?? textToDraw; break;
-                            case SkinMedia.SkinMediaTypes.BackLabel: textToDraw = GarlicSkin.skinSettings?.backlabel ?? textToDraw; break;
-                            case SkinMedia.SkinMediaTypes.FavoriteLabel: textToDraw = GarlicSkin.skinSettings?.favoritelabel ?? textToDraw; break;
+                            case SkinMedia.SkinMediaTypes.NavigateLabel: textToDraw = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.navigatelabel ?? textToDraw; break;
+                            case SkinMedia.SkinMediaTypes.OpenLabel: textToDraw = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.openlabel ?? textToDraw; break;
+                            case SkinMedia.SkinMediaTypes.BackLabel: textToDraw = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.backlabel ?? textToDraw; break;
+                            case SkinMedia.SkinMediaTypes.FavoriteLabel: textToDraw = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.favoritelabel ?? textToDraw; break;
                             case SkinMedia.SkinMediaTypes.SystemName: textToDraw = selectedSystem.folder; break;
                             case SkinMedia.SkinMediaTypes.Clock: textToDraw = DateTime.Now.ToString("HH:mm"); break;
                         }
 
-                        // Load and use the custom font
                         string fontPath = PathConstants.assetSkinPath + "font.ttf";
                         PrivateFontCollection pfc = new PrivateFontCollection();
                         if (File.Exists(fontPath))
                         {
                             pfc.AddFontFile(fontPath);
-                            using (Font font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel))
-                            {
-                                Color finalTextColor = ColorTranslator.FromHtml(textColor);
-                                graphics.DrawString(textToDraw, font, new SolidBrush(finalTextColor), new PointF(skinMedia.X, skinMedia.Y));
-                            }
+                            using Font font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel);
+
+                            SizeF stringSize = graphics.MeasureString(textToDraw, font);
+
+                            float adjustedY = skinMedia.Y - (stringSize.Height / 2);
+
+                            Color finalTextColor = ColorTranslator.FromHtml(textColor);
+                            graphics.DrawString(textToDraw, font, new SolidBrush(finalTextColor), new PointF(skinMedia.X, adjustedY));
                         }
                         break;
                 }
@@ -285,43 +311,62 @@ namespace GarlicPress
 
                 Color textColorInactive = ColorTranslator.FromHtml(GarlicSkin.skinSettings.colorinactive ?? "#AAAAAA");
                 Color textColorActive = ColorTranslator.FromHtml(GarlicSkin.skinSettings.coloractive ?? "#FFFFFF");
-                int fontSize = GarlicSkin.languageFiles?.FirstOrDefault()?.garlicLanguageSettings.fontsize ?? 28;
+                int fontSize = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.fontsize ?? 28;
+                lineHeight = int.Parse(((GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.buttonguidefontsize ?? 28) * 1.5).ToString());
+                startingY = (int)((480 - (lineHeight * 8)) / 2);
 
-                string fontPath = PathConstants.assetSkinPath + "font.ttf";
-                PrivateFontCollection pfc = new PrivateFontCollection();
+                string fontPath = Path.Combine(PathConstants.assetSkinPath, "font.ttf");
+                Font? font = null;
+
                 if (File.Exists(fontPath))
                 {
-                    pfc.AddFontFile(fontPath);
-                    using (Font font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel))
+                    try
                     {
-                        for (int i = 0; i < games.Count && i < 8; i++)
+                        using PrivateFontCollection pfc = new PrivateFontCollection();
+                        pfc.AddFontFile(fontPath);
+
+                        if (pfc.Families.Length > 0)
                         {
-                            string game = games[i];
-                            Color textColor = (game == selectedGame) ? textColorActive : textColorInactive;
-                            var gameTitle = TransformTitle(game).Trim();
-
-                            StringFormat format = new StringFormat();
-                            RectangleF layoutRect;
-                            if (alignment == "right")
-                            {
-                                format.Alignment = StringAlignment.Far;
-                                layoutRect = new RectangleF(0, startingY + (i * lineHeight), canvasWidth - txtMargin, lineHeight);
-                            }
-                            else if (alignment == "center")
-                            {
-                                format.Alignment = StringAlignment.Center;
-                                layoutRect = new RectangleF(0, startingY + (i * lineHeight), canvasWidth, lineHeight);
-                            }
-                            else
-                            {
-                                format.Alignment = StringAlignment.Near;
-                                layoutRect = new RectangleF(txtMargin - 5, startingY + (i * lineHeight), canvasWidth, lineHeight);
-                            }
-
-                            graphics.DrawString(gameTitle, font, new SolidBrush(textColor), layoutRect, format);
+                            font = new Font(pfc.Families[0], fontSize, GraphicsUnit.Pixel);
                         }
                     }
+                    catch
+                    {
+
+                    }
                 }
+
+                if (font is null)
+                {
+                    font = new Font("Arial", fontSize, GraphicsUnit.Pixel);
+                }
+
+                using (font)
+                {
+                    for (int i = 0; i < games.Count && i < 8; i++)
+                    {
+                        string game = games[i];
+                        Color textColor = (game == selectedGame) ? textColorActive : textColorInactive;
+                        var gameTitle = TransformTitle(game).Trim();
+
+                        StringFormat format = new StringFormat
+                        {
+                            Alignment = alignment switch
+                            {
+                                "right" => StringAlignment.Far,
+                                "center" => StringAlignment.Center,
+                                _ => StringAlignment.Near,
+                            }
+                        };
+
+                        float layoutX = alignment == "right" ? 0 : (alignment == "center" ? 0 : txtMargin - 5);
+                        RectangleF layoutRect = new RectangleF(layoutX, startingY + (i * lineHeight), canvasWidth - (alignment == "right" ? txtMargin : 0), lineHeight);
+
+                        using SolidBrush brush = new SolidBrush(textColor);
+                        graphics.DrawString(gameTitle, font, brush, layoutRect, format);
+                    }
+                }
+
             }
             else
             {

--- a/components/MediaGenerationEditor.razor
+++ b/components/MediaGenerationEditor.razor
@@ -410,7 +410,7 @@
                 if (GarlicSkin.skinSettings is not null)
                 {
                     textColor = GarlicSkin.skinSettings.colorguide ?? "#FFFFFF";
-                    fontSize = GarlicSkin.languageFiles?.FirstOrDefault()?.garlicLanguageSettings?.fontsize ?? 28;
+                    fontSize = GarlicSkin.selectedLanguageFile?.garlicLanguageSettings?.buttonguidefontsize ?? 28;
                 }
 
                 switch (skinMedia.SkinMediaType)
@@ -431,16 +431,16 @@
                         await _fabricCanvas.AddText(DateTime.Now.ToString("HH:mm"), skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
                         break;
                     case SkinMedia.SkinMediaTypes.NavigateLabel:
-                        await _fabricCanvas.AddText(GarlicSkin.skinSettings?.navigatelabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
+                        await _fabricCanvas.AddText(GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.navigatelabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
                         break;
                     case SkinMedia.SkinMediaTypes.OpenLabel:
-                        await _fabricCanvas.AddText(GarlicSkin.skinSettings?.openlabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
+                        await _fabricCanvas.AddText(GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.openlabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
                         break;
                     case SkinMedia.SkinMediaTypes.BackLabel:
-                        await _fabricCanvas.AddText(GarlicSkin.skinSettings?.backlabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
+                        await _fabricCanvas.AddText(GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.backlabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
                         break;
                     case SkinMedia.SkinMediaTypes.FavoriteLabel:
-                        await _fabricCanvas.AddText(GarlicSkin.skinSettings?.favoritelabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
+                        await _fabricCanvas.AddText(GarlicSkin.selectedLanguageFile?.garlicLanguageSettings.favoritelabel ?? skinMedia.Text, skinMedia.X, skinMedia.Y, textColor, "GarlicFont", fontSize);
                         break;
                 }
             }
@@ -489,7 +489,7 @@
     {
         if (_fabricCanvas is not null)
         {
-            if (_games.Any() && GarlicSkin.skinSettings is not null && GarlicSkin.languageFiles is not null && GarlicSkin.validSkinSettings)
+            if (_games.Any() && GarlicSkin.skinSettings is not null && GarlicSkin.selectedLanguageFile is not null && GarlicSkin.validSkinSettings)
             {
                 var indexof = _games.IndexOf(_selectedGame);
 
@@ -498,10 +498,10 @@
                 await _fabricCanvas.AddText(
                     String.Join("\n", GameMediaGeneration.GetSurroundingStrings(transformedGames, indexof)),
                     GarlicSkin.skinSettings.textmargin,
-                    70,
+                    480 / 2,
                     GarlicSkin.skinSettings.colorinactive ?? "white",
                     "GarlicFont",
-                    GarlicSkin.languageFiles.First().garlicLanguageSettings.fontsize,
+                    GarlicSkin.selectedLanguageFile.garlicLanguageSettings.fontsize,
                     GarlicSkin.skinSettings.textalignment ?? "left",
                     indexof < 4 ? indexof + 1 : 4,
                     GarlicSkin.skinSettings.coloractive ?? "white");

--- a/components/shared/FabricCanvas.razor.js
+++ b/components/shared/FabricCanvas.razor.js
@@ -87,7 +87,9 @@
                     top: top,
                     angle: 0,
                     selectable: false,
-                    drawOrder: 100
+                    drawOrder: 100,
+                    originX: 'center',
+                    originY: 'center'
                 });
                 BlazorFabric.canvas.add(img);
                 BlazorFabric.canvas.on('object:added', function (options) {
@@ -151,12 +153,14 @@
 
             const text = new fabric.IText(content, {
                 left: left,
-                top: top + 6,
+                top: top,
                 fill: textColor,
                 fontFamily: fontFamily,
                 selectable: false,
                 fontSize: fontSize,
                 textAlign: textAlign,
+                originX: 'center',
+                originY: 'center',
                 lineHeight: 1.35,
                 evented: false
             });

--- a/forms/MainForm.cs
+++ b/forms/MainForm.cs
@@ -209,7 +209,7 @@ namespace GarlicPress
                 using var stream = new FileStream(PathConstants.assetsTempPath + "gameart-down.png", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var oImage = Image.FromStream(stream);
                 using Bitmap overlayImage = new Bitmap(oImage);
-                picGame.Image = GameMediaGeneration.OverlayImageWithSkinBackground(overlayImage, SelectedSystem, filePaths, (fileListBox.SelectedItem as FileStatistics)?.Path ?? imgFile);
+                picGame.Image = GameMediaGeneration.OverlayImageWithSkinBackground(overlayImage, SelectedSystem, filePaths, item.Path);
                 picGame.Refresh();
             }
             else
@@ -217,7 +217,7 @@ namespace GarlicPress
                 using var stream = new FileStream(PathConstants.assetSkinPath + "background.png", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var oImage = Image.FromStream(stream);
                 using Bitmap overlayImage = new Bitmap(oImage);
-                picGame.Image = GameMediaGeneration.OverlayImageWithSkinBackground(overlayImage, SelectedSystem, filePaths, (fileListBox.SelectedItem as FileStatistics)?.Path ?? imgFile);
+                picGame.Image = GameMediaGeneration.OverlayImageWithSkinBackground(overlayImage, SelectedSystem, filePaths, item.Path);
             }
             picGame.Refresh();
         }

--- a/forms/MainForm.cs
+++ b/forms/MainForm.cs
@@ -320,7 +320,7 @@ namespace GarlicPress
                 {
                     txtCurrentTask.Text = "uploading " + file + " for system " + system.name + " to SD " + comboDrive.SelectedIndex + 1;
                     Progress<int> progress = new Progress<int>(p => { txtCurrentTask.Text = $"uploading {p}%"; txtCurrentTask.ForeColor = p > 99 ? Color.Green : Color.OrangeRed; });
-                    await ADBConnection.UploadFileAsync(file, SelectedRomPath + "/" + Path.GetFileName(file).ToLower(), progress, CancellationToken.None);
+                    await ADBConnection.UploadFileAsync(file, SelectedRomPath + "/" + Path.GetFileName(file), progress, CancellationToken.None);
                 }
                 else
                 {

--- a/models/Models.cs
+++ b/models/Models.cs
@@ -1,5 +1,6 @@
 ﻿
 using GarlicPress.classes.bitmapClasses;
+using GarlicPress.constants;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -387,27 +388,27 @@ namespace GarlicPress
 
         public static List<SkinMedia> GetSkinMedias()
         {
-            if (_defaultSkinMedias == null)
+            if (_defaultSkinMedias == null || true)
             {
                 _defaultSkinMedias = new List<SkinMedia>()
         {
-            new SkinMedia() { MediaFileName = "icon-dpad-54.png", X = 5, Y = 420, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 55, Y = 427, Text = "NAVIGATE", SkinMediaType = SkinMediaTypes.NavigateLabel },
+            new SkinMedia() { MediaFileName = "icon-dpad-54.png", X = 20, Y = 460, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 40, Y = 460, Text = "NAVIGATE", SkinMediaType = SkinMediaTypes.NavigateLabel },
 
-            new SkinMedia() { MediaFileName = "icon-A-54.png", X = 195, Y = 420, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 245, Y = 427, Text = "OPEN", SkinMediaType = SkinMediaTypes.OpenLabel },
+            new SkinMedia() { MediaFileName = "icon-A-54.png", X = 210, Y = 460, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 230, Y = 460, Text = "OPEN", SkinMediaType = SkinMediaTypes.OpenLabel },
 
-            new SkinMedia() { MediaFileName = "icon-B-54.png", X = 325, Y = 420, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 375, Y = 427, Text = "BACK", SkinMediaType = SkinMediaTypes.BackLabel },
+            new SkinMedia() { MediaFileName = "icon-B-54.png", X = 340, Y = 460, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 360, Y = 460, Text = "BACK", SkinMediaType = SkinMediaTypes.BackLabel },
 
-            new SkinMedia() { MediaFileName = "icon-Y-54.png", X = 450, Y = 420, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 500, Y = 427, Text = "FAVORITE", SkinMediaType = SkinMediaTypes.FavoriteLabel },
+            new SkinMedia() { MediaFileName = "icon-Y-54.png", X = 465, Y = 460, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 485, Y = 460, Text = "FAVORITE", SkinMediaType = SkinMediaTypes.FavoriteLabel },
 
-            new SkinMedia() { MediaFileName = "logo.png", X = 15, Y = 8, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 57, Y = 10, Text = "", SkinMediaType = SkinMediaTypes.SystemName },
+            new SkinMedia() { MediaFileName = "logo.png", X = 37, Y = 25, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 60, Y = 25, Text = "", SkinMediaType = SkinMediaTypes.SystemName },
 
-            new SkinMedia() { MediaFileName = "charging-05.png", X = 580, Y = 5, Text = "", SkinMediaType = SkinMediaTypes.Picture },
-            new SkinMedia() { MediaFileName = "", X = 490, Y = 10, Text = "", SkinMediaType = SkinMediaTypes.Clock },
+            new SkinMedia() { MediaFileName = "charging-05.png", X = 600, Y = 25, Text = "", SkinMediaType = SkinMediaTypes.Picture },
+            new SkinMedia() { MediaFileName = "", X = 480, Y = 25, Text = "", SkinMediaType = SkinMediaTypes.Clock },
         };
             }
             return _defaultSkinMedias;

--- a/models/Models.cs
+++ b/models/Models.cs
@@ -389,7 +389,7 @@ namespace GarlicPress
 
         public static List<SkinMedia> GetSkinMedias()
         {
-            if (_defaultSkinMedias == null || true)
+            if (_defaultSkinMedias == null)
             {
                 _defaultSkinMedias = new List<SkinMedia>()
         {


### PR DESCRIPTION
While I couldn't reproduce the specific error in #99, I've made a few code adjustments:
- Revised the code associated with `surroundingGames` and getting the custom `Font`.
- Introduced `TryCatch` for game text and skin media, with errors now being directed to the debug log rather than causing a throw.

I've made changes to the handling of skin text and images. They now use the center as their origin point to better accommodate different skins. It's worth noting that it's not yet perfect, GarlicOS seems to display varying positions based on font size. Here are a couple of examples:

**Example 1**
![image](https://github.com/prosthetichead/GarlicPress/assets/8648447/af4d33ac-a218-47c8-85c2-62b0b6a090ce)

**Example 2**
![image](https://github.com/prosthetichead/GarlicPress/assets/8648447/f1f6a54c-fed5-47b9-b13f-44a61fbb9353)

Additionally, I've adjusted the system so that the correct skin language file is chosen for displaying text and font during the generation of previews.

Removed ToLower() when transferring files to device. Fixes #100.